### PR TITLE
New CFLAGs for optimized function calls

### DIFF
--- a/etc/portage/make.conf
+++ b/etc/portage/make.conf
@@ -18,7 +18,7 @@ AR="gcc-ar"
 NM="gcc-nm"
 RANLIB="gcc-ranlib"
 
-CFLAGS="-Ofast -pipe -flto=8 -funroll-loops -floop-block -floop-interchange -floop-strip-mine -ftree-loop-distribution"
+CFLAGS="-Ofast -pipe -flto=8 -falign-functions=64 -falign-labels=64 -funroll-loops -floop-block -floop-interchange -floop-strip-mine -ftree-loop-distribution"
 CXXFLAGS="${CFLAGS}"
 
 USE="-kde -gnome -systemd -pulseaudio -libav -avahi -zeroconf -openal -gstreamer -udisks -qt3support -qt4 -multilib -nls bindist ipv6 minimal jpeg gif png offensive zsh-completion custom-cflags custom-optimization cpudetection threads aio smp nptl lto graphite pgo numa cxx alsa opengl glamor vaapi vdpau xvmc"


### PR DESCRIPTION
This PR adds the `-falign-functions=64 -falign-labels=64` flag to optimize function calls on 64 bit by making all function addresses aligned. They compliment each other as well as the `-flto=8` flag and will make the system much faster as long as the architecture corresponds to 8-byte aligned function addresses(it will on amd64).